### PR TITLE
Batch handler fixes

### DIFF
--- a/api/v1/batch_handler.go
+++ b/api/v1/batch_handler.go
@@ -78,21 +78,25 @@ func (h *RouteHandler) batchHandler(c *gin.Context) {
 		msg.SkewTimestamp()
 
 		// Merge batch level context to msg context
-		err := msg.MergeContext(batch.Context)
-		if err != nil {
-			action := "merge-context"
-			c.Set("action", action)
-			c.Set("error", err.Error())
-			log.WithFields(logrus.Fields{"action": action}).Error(err.Error())
+		if batch.Context != nil {
+			err := msg.MergeContext(batch.Context)
+			if err != nil {
+				action := "merge-context"
+				c.Set("action", action)
+				c.Set("error", err.Error())
+				log.WithFields(logrus.Fields{"action": action}).Error(err.Error())
+			}
 		}
 
 		// Merge batch level integrations to msg integrations
-		err = msg.MergeIntegrations(batch.Integrations)
-		if err != nil {
-			action := "merge-integrations"
-			c.Set("action", action)
-			c.Set("error", err.Error())
-			log.WithFields(logrus.Fields{"action": action}).Error(err.Error())
+		if batch.Integrations != nil {
+			err = msg.MergeIntegrations(batch.Integrations)
+			if err != nil {
+				action := "merge-integrations"
+				c.Set("action", action)
+				c.Set("error", err.Error())
+				log.WithFields(logrus.Fields{"action": action}).Error(err.Error())
+			}
 		}
 
 		// Pass the msg along to the adapter

--- a/types/convertible_boolean.go
+++ b/types/convertible_boolean.go
@@ -1,0 +1,23 @@
+package types
+
+import (
+	"github.com/sirupsen/logrus"
+	"github.com/arizz96/event-api/logging"
+)
+
+type ConvertibleBoolean bool
+
+func (bit *ConvertibleBoolean) UnmarshalJSON(data []byte) error {
+	log := logging.GetLogger(logrus.Fields{"package": "types"})
+
+  asString := string(data)
+	if asString == "1" || asString == "true" {
+		*bit = true
+	} else if asString == "0" || asString == "false" {
+		*bit = false
+	} else {
+		log.WithFields(logrus.Fields{"action": "Error during ConvertibleBoolean unmarshal"})
+	}
+
+	return nil
+}

--- a/types/convertible_string.go
+++ b/types/convertible_string.go
@@ -1,0 +1,18 @@
+package types
+
+import(
+	"strconv"
+)
+
+type ConvertibleString string
+
+func (str *ConvertibleString) UnmarshalJSON(data []byte) error {
+	s, err := strconv.Unquote(string(data))
+	if err != nil {
+		*str = ConvertibleString(data)
+	} else {
+		*str = ConvertibleString(s)
+	}
+
+	return nil
+}

--- a/types/v1/context.go
+++ b/types/v1/context.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"net"
+	"github.com/arizz96/event-api/types"
 )
 
 // Context provides the representation of the `context` object
@@ -25,10 +26,10 @@ type Context struct {
 
 // AppInfo provides the representation of the `context.app` object
 type AppInfo struct {
-	Name      string `json:"name,omitempty"`
-	Version   string `json:"version,omitempty"`
-	Build     string `json:"build,omitempty"`
-	Namespace string `json:"namespace,omitempty"`
+	Name      string                  `json:"name,omitempty"`
+	Version   string                  `json:"version,omitempty"`
+	Build     types.ConvertibleString `json:"build,omitempty"`
+	Namespace string                  `json:"namespace,omitempty"`
 }
 
 // CampaignInfo provides the representation of the `context.campaign` object
@@ -69,10 +70,10 @@ type LocationInfo struct {
 
 // NetworkInfo provides the representation of the `context.network` object
 type NetworkInfo struct {
-	Bluetooth bool   `json:"bluetooth,omitempty"`
-	Cellular  bool   `json:"cellular,omitempty"`
-	WIFI      bool   `json:"wifi,omitempty"`
-	Carrier   string `json:"carrier,omitempty"`
+	Bluetooth types.ConvertibleBoolean `json:"bluetooth,omitempty"`
+	Cellular  types.ConvertibleBoolean `json:"cellular,omitempty"`
+	WIFI      types.ConvertibleBoolean `json:"wifi,omitempty"`
+	Carrier   string                   `json:"carrier,omitempty"`
 }
 
 // OSInfo provides the representation of the `context.os` object

--- a/types/v1/event.go
+++ b/types/v1/event.go
@@ -27,9 +27,19 @@ func (ev *Event) GetWriteKey() string {
 	return ev.WriteKey
 }
 
-// GetMessageID returns the write key
+// GetMessageID returns the message's ID
 func (ev *Event) GetMessageID() string {
 	return ev.MessageID
+}
+
+// GetMessageID returns the message's Context
+func (ev *Event) GetContext() *Context {
+	return ev.Context
+}
+
+// GetMessageID returns the message's Integrations
+func (ev *Event) GetIntegrations() *Integrations {
+	return ev.Integrations
 }
 
 // GetType returns the write key

--- a/types/v1/message.go
+++ b/types/v1/message.go
@@ -6,6 +6,8 @@ import "time"
 type Message interface {
 	GetWriteKey() string
 	GetMessageID() string
+	GetContext() *Context
+	GetIntegrations() *Integrations
 	GetType() string
 	WithSentAt(time.Time)
 	WithReceivedAt(time.Time)


### PR DESCRIPTION
Due to changes on segment APIs, clients can now send Context and Integrations inside every batch message.
This patch handles them, allowing to have a global Context that will be merged to every message (only if their is nil), if specified, otherwise it tries to preserve messages' Context.